### PR TITLE
Notify SockJS client when connecting to a STOMP URL using HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Don’t commit the following directories created by pub.
 build/
 packages/
+example/packages
+.packages
 
 # Or the files created by dart2js.
 *.dart.js

--- a/lib/stomp_sockjs.dart
+++ b/lib/stomp_sockjs.dart
@@ -19,6 +19,7 @@ Future<StompClient> connect(String url, {
         void onClose(),
         bool debugFlag:false
       }) {
+        SockJS.WebSocketTransport.probeSecure = url.startsWith('https');
         Future<Object> waitingForConnection = _SockDartConnector.start(url, protocolsWhiteList, debugFlag,
           onClose: onClose);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,12 @@
 name: stomp_sockjs
-version: 0.1.0
+version: 0.2.0
 author: Tamas Kiss <stompsockjsdart@gmail.com>
 description: A pub package
 homepage: https://github.com/tomikiss/stomp_sockjs
 dependencies:
-  sockjs_client: any
+  #sockjs_client: '>= 0.3.0'
+  sockjs_client:
+    git:
+      url: git@github.com:dougreese/sockjs-dart-client.git
+      ref: 0.3.0
   stomp: any


### PR DESCRIPTION
The sockjs_client package was modified to work better over HTTPS. See issue: https://github.com/nelsonsilva/sockjs-dart-client/issues/10

This package must notify the sockjs_client when it should use a secure connection in its internal protocol detection routines.  Ideally sockjs_client would do this automatically, but some non-trivial refactoring would likely be involved.

There is no change to the behavior of code using this package.

Note: The sockjs_client dependency is temporary until the updated sockjs_client package is updated on pub.  If/when that happens, change the sockjs_client dependency from

```
  sockjs_client:
    git:
      url: git@github.com:dougreese/sockjs-dart-client.git
      ref: 0.3.0
```

to

```
  sockjs_client: '>= 0.3.0'
```
